### PR TITLE
Fix typescript errors in plugins

### DIFF
--- a/src/privcordplugins/betterMicrophone.desktop/components/MicrophoneSettingsModal.tsx
+++ b/src/privcordplugins/betterMicrophone.desktop/components/MicrophoneSettingsModal.tsx
@@ -292,6 +292,7 @@ export const MicrophoneSettingsModal = (props: MicrophoneSettingsModalProps) => 
                     {simpleToggle}
                 </Flex>
             }
+            transitionState={props.transitionState}
             {...props}
             onDone={() => {
                 props.onClose();

--- a/src/privcordplugins/betterScreenshare.desktop/components/ScreenshareSettingsModal.tsx
+++ b/src/privcordplugins/betterScreenshare.desktop/components/ScreenshareSettingsModal.tsx
@@ -430,6 +430,7 @@ export const ScreenshareSettingsModal = (props: ScreenshareSettingsModalProps) =
                     {simpleToggle}
                 </Flex>
             }
+            transitionState={props.transitionState}
             {...props}
             onDone={() => {
                 props.onClose();

--- a/src/privcordplugins/betterScreenshare.desktop/patchers/screenshareAudio.ts
+++ b/src/privcordplugins/betterScreenshare.desktop/patchers/screenshareAudio.ts
@@ -17,6 +17,7 @@
 */
 
 import { UserStore } from "@webpack/common";
+import EventEmitter from "events";
 
 import { Emitter, MediaEngineStore, patchConnectionAudioTransportOptions, Patcher, types } from "../../philsPluginLibrary";
 import { PluginInfo } from "../constants";
@@ -59,20 +60,46 @@ export class ScreenshareAudioPatcher extends Patcher {
                 this.forceUpdateTransportationOptions = forceUpdateTransportationOptionsAudio;
                 this.oldSetTransportOptions = oldSetTransportOptionsAudio;
 
-                Emitter.addListener(connection.emitter as any, "on" as any, "connected" as any, () => {
-                    this.forceUpdateTransportationOptions();
-                });
+                const addUntypedListener = Emitter.addListener as unknown as (
+                    emitter: EventEmitter,
+                    type: "on" | "once",
+                    event: string,
+                    fn: (...args: any[]) => void,
+                    plugin?: string
+                ) => () => void;
 
-                Emitter.addListener(connection.emitter as any, "on" as any, "destroy" as any, () => {
-                    this.forceUpdateTransportationOptions = () => void 0;
-                });
+                addUntypedListener(
+                    connection.emitter as unknown as EventEmitter,
+                    "on",
+                    "connected",
+                    () => {
+                        this.forceUpdateTransportationOptions();
+                    }
+                );
+
+                addUntypedListener(
+                    connection.emitter as unknown as EventEmitter,
+                    "on",
+                    "destroy",
+                    () => {
+                        this.forceUpdateTransportationOptions = () => void 0;
+                    }
+                );
             };
 
-        Emitter.addListener(
-            this.mediaEngine.emitter as any,
-            "on" as any,
-            "connection" as any,
-            connectionEventFunction as any,
+        const addUntypedListener = Emitter.addListener as unknown as (
+            emitter: EventEmitter,
+            type: "on" | "once",
+            event: string,
+            fn: (...args: any[]) => void,
+            plugin?: string
+        ) => () => void;
+
+        addUntypedListener(
+            this.mediaEngine.emitter as unknown as EventEmitter,
+            "on",
+            "connection",
+            connectionEventFunction,
             PluginInfo.PLUGIN_NAME
         );
 


### PR DESCRIPTION
Fix TypeScript compilation errors by passing `transitionState` to `SettingsModal` and correcting `Emitter.addListener` type inference.

The `Emitter.addListener` helper was inferring `never` for event arguments when used with `any` types, leading to `any` to `never` assignment errors. Explicitly casting `Emitter.addListener` to an untyped overload that accepts `EventEmitter` and string event names resolves this without changing runtime behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbb510fc-315e-450e-a893-382d6158c20c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fbb510fc-315e-450e-a893-382d6158c20c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

